### PR TITLE
doesnt build

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "next": "14.0.3",
     "react": "^18",
     "react-dom": "^18",
-    "use-fireproof": "^0.14.2"
+    "use-fireproof": "^0.19.111"
   },
   "devDependencies": {
     "@types/node": "^20",


### PR DESCRIPTION
whatever is in this build env doens't like out package

```
node:fs/promises
Module build failed: UnhandledSchemeError: Reading from "node:fs/promises" is not handled by plugins (Unhandled scheme).
Webpack supports "data:" and "file:" URIs by default.
You may need an additional plugin to handle "node:" URIs.
```